### PR TITLE
Remove the -100000 which are defaulted in kavita

### DIFF
--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -121,10 +121,10 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 				const item: any = {
 					id: `${chapter.id}`,
 					mangaId: mangaId,
-					chapNum: chapter.isSpecial ? j++ : parseFloat(chapter.number), // chapter.number is 0 when it's a special
+					chapNum: chapter.number === "-100000" ? 1 : (chapter.isSpecial ? j++ : parseFloat(chapter.number)), // chapter.number is 0 when it's a special
 					name: chapter.isSpecial ? title : name,
 					time: new Date(chapter.releaseDate === '0001-01-01T00:00:00' ? chapter.created : chapter.releaseDate),
-					volume: parseFloat(volume.name),
+					...(volume.name !== "-100000" && { volume: parseFloat(volume.name) }),
 					group: `${(chapter.isSpecial ? 'Specials · ' : '')}${chapter.pages} pages ${progress}`,
 					_index: i++,
 					// sortIndex is unused, as it seems to have an issue when changing the sort order

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -124,7 +124,7 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 					chapNum: chapter.number === "-100000" ? 1 : (chapter.isSpecial ? j++ : parseFloat(chapter.number)), // chapter.number is 0 when it's a special
 					name: chapter.isSpecial ? title : name,
 					time: new Date(chapter.releaseDate === '0001-01-01T00:00:00' ? chapter.created : chapter.releaseDate),
-					...(volume.name !== "-100000" && { volume: parseFloat(volume.name) }),
+					volume: chapter.isSpecial ? 0 : volume.name === "-100000" ? 0 : parseFloat(volume.name) , // assign both special and chapters w/o volumes w/ volume 0 as it's hidden by paperback
 					group: `${(chapter.isSpecial ? 'Specials · ' : '')}${chapter.pages} pages ${progress}`,
 					_index: i++,
 					// sortIndex is unused, as it seems to have an issue when changing the sort order


### PR DESCRIPTION
Volume num is now conditional based on whether or not it's -100000, whereas the chapter num gets set to 1 (expected behavior for paperback as it requires a ch #) if it's detected as -100000 

This also reverts the sort order back to the old behavior, where the volumes are at the bottom and chapters are at the top - logically, chapters are assumed to be newer than volumes as they haven't been collected into a volume yet