### PR TITLE
Reading Lists support

### DIFF
--- a/src/Kavya/Common.ts
+++ b/src/Kavya/Common.ts
@@ -147,6 +147,51 @@ export async function getSeriesDetails(mangaId: string, requestManager: RequestM
 	};
 }
 
+export async function getReadingListDetails(mangaId: string, requestManager: RequestManager, stateManager: SourceStateManager) {
+	const kavitaAPI = await getKavitaAPI(stateManager);
+	const readingListId = mangaId.replace('rl-', '');
+
+	const readingListRequest = App.createRequest({
+		url: `${kavitaAPI.url}/ReadingList?readingListId=${readingListId}`,
+		method: 'GET',
+	})
+
+	const readingListMetadataRequest = App.createRequest({
+		url: `${kavitaAPI.url}/ReadingList/all-people?readingListId=${readingListId}`,
+		method: 'GET',
+	})
+
+	const promises: Promise<Response>[] = [];
+
+	promises.push(requestManager.schedule(readingListRequest, 1));
+	promises.push(requestManager.schedule(readingListMetadataRequest, 1));
+
+	const responses: Response[] = await Promise.all(promises);
+
+	const readingListResult = typeof responses[0]?.data === 'string' ? JSON.parse(responses[0]?.data) : responses[0]?.data;
+	const readingListMetadataResult = typeof responses[1]?.data === 'string' ? JSON.parse(responses[1]?.data) : responses[1]?.data;
+
+	let artists = [];
+	for (const penciller of readingListMetadataResult.pencillers) {
+		artists.push(penciller.name);
+	}
+
+	let authors = [];
+	for (const writer of readingListMetadataResult.writers) {
+		authors.push(writer.name);
+	}
+
+	return {
+		image: `${kavitaAPI.url}/image/readinglist-cover?readingListId=${readingListId}&apiKey=${kavitaAPI.key}`,
+		artist: artists.join(', '),
+		author: authors.join(', '),
+		desc: "",
+		status: 'Unknown',
+		hentai: false,
+		titles: [readingListResult.title],
+	};
+}
+
 export function reqeustToString(request: Request): string {
 	return JSON.stringify({
 		url: request.url,

--- a/src/Kavya/Common.ts
+++ b/src/Kavya/Common.ts
@@ -175,6 +175,7 @@ export const DEFAULT_VALUES: any = {
 	showOnDeck: true,
 	showRecentlyUpdated: true,
 	showNewlyAdded: true,
+	showReadingLists: true,
 	excludeUnsupportedLibrary: false,
 	
 	enableRecursiveSearch: false
@@ -211,6 +212,7 @@ export async function getOptions(
 	showOnDeck: boolean;
 	showRecentlyUpdated: boolean;
 	showNewlyAdded: boolean;
+	showReadingLists: boolean;
 	excludeUnsupportedLibrary: boolean;
 	enableRecursiveSearch: boolean;
 }> {
@@ -218,9 +220,10 @@ export async function getOptions(
 	const showOnDeck = (await stateManager.retrieve('showOnDeck') as boolean) ?? DEFAULT_VALUES.showOnDeck;
 	const showRecentlyUpdated = (await stateManager.retrieve('showRecentlyUpdated') as boolean) ?? DEFAULT_VALUES.showRecentlyUpdated;
 	const showNewlyAdded = (await stateManager.retrieve('showNewlyAdded') as boolean) ?? DEFAULT_VALUES.showNewlyAdded;
+	const showReadingLists = (await stateManager.retrieve('showReadingLists') as boolean) ?? DEFAULT_VALUES.showReadingLists;
 	const excludeUnsupportedLibrary = (await stateManager.retrieve('excludeUnsupportedLibrary') as boolean) ?? DEFAULT_VALUES.excludeUnsupportedLibrary;
 
 	const enableRecursiveSearch = (await stateManager.retrieve('enableRecursiveSearch') as boolean) ?? DEFAULT_VALUES.enableRecursiveSearch;
 
-	return { pageSize, showOnDeck, showRecentlyUpdated, showNewlyAdded, excludeUnsupportedLibrary, enableRecursiveSearch };
+	return { pageSize, showOnDeck, showRecentlyUpdated, showNewlyAdded, showReadingLists, excludeUnsupportedLibrary, enableRecursiveSearch };
 }

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -263,7 +263,7 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 		// We won't use `await this.getKavitaAPI()` as we do not want to throw an error on
 		// the homepage when server settings are not set
 		const kavitaAPI = await getKavitaAPI(this.stateManager);
-		const { showOnDeck, showRecentlyUpdated, showNewlyAdded, excludeUnsupportedLibrary } = await getOptions(this.stateManager);
+		const { showOnDeck, showRecentlyUpdated, showNewlyAdded, showReadingLists, excludeUnsupportedLibrary } = await getOptions(this.stateManager);
 		const pageSize = (await getOptions(this.stateManager)).pageSize / 2;
 
 		// The source define two homepage sections: new and latest
@@ -291,6 +291,16 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 			sections.push(App.createHomeSection({
 				id: 'newlyadded',
 				title: 'Newly Added Series',
+				containsMoreItems: false,
+				type: 'singleRowNormal'
+			}));
+		}
+
+		/* Reading Lists */
+		if(showReadingLists){
+			sections.push(App.createHomeSection({
+				id:'readinglists',
+				title: 'Reading Lists',
 				containsMoreItems: false,
 				type: 'singleRowNormal'
 			}));
@@ -327,7 +337,7 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 		}
 
 		for (const section of sections) {
-			let apiPath: string, body: any = {}, id: string = 'id', title: string = 'name';
+			let apiPath: string, body: any = {}, id: string = 'id', title: string = 'name', isReadingList: boolean = false;
 			switch (section.id) {
 				case 'ondeck':
 					apiPath = `${kavitaAPI.url}/Series/on-deck?PageNumber=1&PageSize=${pageSize}`;
@@ -338,6 +348,11 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 					break;
 				case 'newlyadded':
 					apiPath = `${kavitaAPI.url}/Series/recently-added-v2?PageNumber=1&PageSize=${pageSize}`;
+					break;
+				case 'readinglists':
+					apiPath = `${kavitaAPI.url}/ReadingList/lists`;
+					title = 'title';
+					isReadingList = true;
 					break;
 				default:
 					apiPath = `${kavitaAPI.url}/Series/v2?PageNumber=1&PageSize=${pageSize}`;
@@ -366,12 +381,22 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 					
 					for (const series of result) {
 						if (excludeUnsupportedLibrary && excludeLibraryIds.includes(series.libraryId)) continue;
-						tiles.push(App.createPartialSourceManga({
-							title: series[title],
-							image: `${kavitaAPI.url}/image/series-cover?seriesId=${series[id]}&apiKey=${kavitaAPI.key}`,
-							mangaId: `${series[id]}`,
-							subtitle: undefined
-						}));
+
+						if (isReadingList) {
+							tiles.push(App.createPartialSourceManga({
+								title: series[title],
+								image: `${kavitaAPI.url}/Image/readinglist-cover?readingListId=${series[id]}&apiKey=${kavitaAPI.key}`,
+								mangaId: `rl-${series[id]}`,
+								subtitle: undefined
+							}));
+						} else {
+							tiles.push(App.createPartialSourceManga({
+								title: series[title],
+								image: `${kavitaAPI.url}/image/series-cover?seriesId=${series[id]}&apiKey=${kavitaAPI.key}`,
+								mangaId: `${series[id]}`,
+								subtitle: undefined
+							}));
+						}
 					}
 					
 					section.items = tiles;

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -100,39 +100,74 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 	async getChapters(mangaId: string): Promise<Chapter[]> {
 		const kavitaAPI = await getKavitaAPI(this.stateManager);
 
-		const request = App.createRequest({
-			url: `${kavitaAPI.url}/Series/volumes`,
-			param: `?seriesId=${mangaId}`,
-			method: 'GET',
-		});
-
-		const response = await this.requestManager.schedule(request, 1);
-		const result = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
-
 		const chapters: any[] = [], specials: any[] = [];
 
-		let i = 0;
-		let j = 1;
-		for (const volume of result) {
-			for (const chapter of volume.chapters) {
-				const name = chapter.number === chapter.range ? chapter.titleName ?? '' : `${chapter.range.replace(`${chapter.number}-`, '')}${chapter.titleName ? ` - ${chapter.titleName}` : ''}`;
-				const title: string = chapter.range.endsWith('.epub') ? chapter.range.slice(0, -5) : chapter.range.slice(0, -4);
-				const progress: string = chapter.pagesRead === 0 ? '' : chapter.pages === chapter.pagesRead ? '· Read' : `· Reading ${chapter.pagesRead} page`;
+		if(mangaId.startsWith('rl-'))
+		{
+			const request = App.createRequest({
+				url: `${kavitaAPI.url}/ReadingList/items`,
+				param: `?readingListId=${mangaId.replace('rl-', '')}`,
+				method: 'GET'
+			});
+
+			const response = await this.requestManager.schedule(request, 1);
+			const result = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
+
+			let i = 0;
+			let j = 1;
+
+			for (const rlItem of result) {
+				const progress: string = rlItem.pagesRead === 0 ? '' : rlItem.pagesTotal === rlItem.pagesRead ? '· Read' : `· Reading ${rlItem.pagesRead} page`;
 				
 				const item: any = {
-					id: `${chapter.id}`,
-					mangaId: mangaId,
-					chapNum: chapter.number === '-100000' ? 1 : (chapter.isSpecial ? j++ : parseFloat(chapter.number)), // chapter.number is 0 when it's a special
-					name: chapter.isSpecial ? title : name,
-					time: new Date(chapter.releaseDate === '0001-01-01T00:00:00' ? chapter.created : chapter.releaseDate),
-					volume: chapter.isSpecial ? 0 : volume.name === '-100000' ? 0 : parseFloat(volume.name) , // assign both special and chapters w/o volumes w/ volume 0 as it's hidden by paperback
-					group: `${(chapter.isSpecial ? 'Specials · ' : '')}${chapter.pages} pages ${progress}`,
+					id: `${rlItem.chapterId}`,
+					mangaId: rlItem.seriesId,
+					chapNum: rlItem.chapterNumber === '-100000' ? 1 : (rlItem.isSpecial ? j++ : parseFloat(rlItem.chapterNumber)), // chapter.number is 0 when it's a special
+					name: rlItem.seriesName, // Since a Reading List is composed by various series, the serie name will be printed here instead of the chapter name
+					time: new Date(rlItem.releaseDate),
+					volume: rlItem.isSpecial ? 0 : rlItem.volumeNumber === '-100000' ? 0 : parseFloat(rlItem.volumeNumber) , // assign both special and chapters w/o volumes w/ volume 0 as it's hidden by paperback
+					group: `${(rlItem.isSpecial ? 'Specials · ' : '')}${rlItem.pagesTotal} pages ${progress}`,
 					_index: i++,
 					// sortIndex is unused, as it seems to have an issue when changing the sort order
 				};
 				
-				if (chapter.isSpecial) specials.push(item);
+				if (rlItem.isSpecial) specials.push(item);
 				else chapters.push(item);
+			}
+		} else {
+			const request = App.createRequest({
+				url: `${kavitaAPI.url}/Series/volumes`,
+				param: `?seriesId=${mangaId}`,
+				method: 'GET',
+			});
+
+			const response = await this.requestManager.schedule(request, 1);
+			const result = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
+
+			let i = 0;
+			let j = 1;
+			
+			for (const volume of result) {
+				for (const chapter of volume.chapters) {
+					const name = chapter.number === chapter.range ? chapter.titleName ?? '' : `${chapter.range.replace(`${chapter.number}-`, '')}${chapter.titleName ? ` - ${chapter.titleName}` : ''}`;
+					const title: string = chapter.range.endsWith('.epub') ? chapter.range.slice(0, -5) : chapter.range.slice(0, -4);
+					const progress: string = chapter.pagesRead === 0 ? '' : chapter.pages === chapter.pagesRead ? '· Read' : `· Reading ${chapter.pagesRead} page`;
+					
+					const item: any = {
+						id: `${chapter.id}`,
+						mangaId: mangaId,
+						chapNum: chapter.number === '-100000' ? 1 : (chapter.isSpecial ? j++ : parseFloat(chapter.number)), // chapter.number is 0 when it's a special
+						name: chapter.isSpecial ? title : name,
+						time: new Date(chapter.releaseDate === '0001-01-01T00:00:00' ? chapter.created : chapter.releaseDate),
+						volume: chapter.isSpecial ? 0 : volume.name === '-100000' ? 0 : parseFloat(volume.name) , // assign both special and chapters w/o volumes w/ volume 0 as it's hidden by paperback
+						group: `${(chapter.isSpecial ? 'Specials · ' : '')}${chapter.pages} pages ${progress}`,
+						_index: i++,
+						// sortIndex is unused, as it seems to have an issue when changing the sort order
+					};
+					
+					if (chapter.isSpecial) specials.push(item);
+					else chapters.push(item);
+				}
 			}
 		}
 

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -120,7 +120,7 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 					id: `${rlItem.chapterId}`,
 					mangaId: rlItem.seriesId,
 					chapNum: rlItem.order + 1,
-					name: `${rlItem.seriesName} - Issue ${rlItem.chapterNumber}`,
+					name: `${rlItem.seriesName} #${rlItem.chapterNumber}`,
 					time: new Date(rlItem.releaseDate),
 					group: `${(rlItem.isSpecial ? 'Specials · ' : '')}${rlItem.pagesTotal} pages ${progress}`,
 					_index: rlItem.order,

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -31,6 +31,7 @@ import {
 	getKavitaAPI,
 	getOptions,
 	getSeriesDetails,
+	getReadingListDetails,
 	getServerUnavailableMangaTiles,
 	reqeustToString
 } from './Common';
@@ -84,10 +85,14 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 	}
 
 	async getMangaDetails(mangaId: string): Promise<SourceManga> {
+		const detailsFunction = mangaId.startsWith('rl-') 
+			? getReadingListDetails 
+			: getSeriesDetails;
+			
 		return App.createSourceManga({
 			id: mangaId,
 			mangaInfo: App.createMangaInfo({
-				...(await getSeriesDetails(mangaId, this.requestManager, this.stateManager))
+				...(await detailsFunction(mangaId, this.requestManager, this.stateManager))
 			})
 		});
 	}

--- a/src/Kavya/Kavya.ts
+++ b/src/Kavya/Kavya.ts
@@ -113,22 +113,17 @@ export class Kavya implements ChapterProviding, HomePageSectionsProviding, Manga
 			const response = await this.requestManager.schedule(request, 1);
 			const result = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
 
-			let i = 0;
-			let j = 1;
-
 			for (const rlItem of result) {
 				const progress: string = rlItem.pagesRead === 0 ? '' : rlItem.pagesTotal === rlItem.pagesRead ? '· Read' : `· Reading ${rlItem.pagesRead} page`;
 				
 				const item: any = {
 					id: `${rlItem.chapterId}`,
 					mangaId: rlItem.seriesId,
-					chapNum: rlItem.chapterNumber === '-100000' ? 1 : (rlItem.isSpecial ? j++ : parseFloat(rlItem.chapterNumber)), // chapter.number is 0 when it's a special
-					name: rlItem.seriesName, // Since a Reading List is composed by various series, the serie name will be printed here instead of the chapter name
+					chapNum: rlItem.order + 1,
+					name: `${rlItem.seriesName} - Issue ${rlItem.chapterNumber}`,
 					time: new Date(rlItem.releaseDate),
-					volume: rlItem.isSpecial ? 0 : rlItem.volumeNumber === '-100000' ? 0 : parseFloat(rlItem.volumeNumber) , // assign both special and chapters w/o volumes w/ volume 0 as it's hidden by paperback
 					group: `${(rlItem.isSpecial ? 'Specials · ' : '')}${rlItem.pagesTotal} pages ${progress}`,
-					_index: i++,
-					// sortIndex is unused, as it seems to have an issue when changing the sort order
+					_index: rlItem.order,
 				};
 				
 				if (rlItem.isSpecial) specials.push(item);

--- a/src/Kavya/Settings.ts
+++ b/src/Kavya/Settings.ts
@@ -121,6 +121,19 @@ export const serverSettingsMenu = (
 							})
 						}),
 						App.createDUISwitch({
+							id: 'showReadingLists',
+							label: 'Show Reading Lists',
+							value: App.createDUIBinding({
+								async get() {
+									return values.showReadingLists;
+								},
+								async set(value) {
+									values.showReadingLists = value;
+									await setStateData(stateManager, interceptor, values);
+								}
+							})
+						}),
+						App.createDUISwitch({
 							id: 'excludeUnsupportedLibrary',
 							label: 'Exclude Book & Novel Type Libraries',
 							value: App.createDUIBinding({
@@ -169,11 +182,12 @@ export async function retrieveStateData(stateManager: SourceStateManager) {
 	const showOnDeck = (await stateManager.retrieve('showOnDeck') as boolean) ?? DEFAULT_VALUES.showOnDeck;
 	const showRecentlyUpdated = (await stateManager.retrieve('showRecentlyUpdated') as boolean) ?? DEFAULT_VALUES.showRecentlyUpdated;
 	const showNewlyAdded = (await stateManager.retrieve('showNewlyAdded') as boolean) ?? DEFAULT_VALUES.showNewlyAdded;
+	const showReadingLists = (await stateManager.retrieve('showReadingLists') as boolean) ?? DEFAULT_VALUES.showReadingLists;
 	const excludeUnsupportedLibrary = (await stateManager.retrieve('excludeUnsupportedLibrary') as boolean) ?? DEFAULT_VALUES.excludeUnsupportedLibrary;
 
 	const enableRecursiveSearch = (await stateManager.retrieve('enableRecursiveSearch') as boolean) ?? DEFAULT_VALUES.enableRecursiveSearch;
 
-	return { kavitaAddress, kavitaAPIKey, pageSize, showOnDeck, showRecentlyUpdated, showNewlyAdded, excludeUnsupportedLibrary, enableRecursiveSearch }
+	return { kavitaAddress, kavitaAPIKey, pageSize, showOnDeck, showRecentlyUpdated, showNewlyAdded, showReadingLists, excludeUnsupportedLibrary, enableRecursiveSearch }
 }
 
 export async function setStateData(stateManager: SourceStateManager, interceptor: KavitaRequestInterceptor, data: Record<string, any>) {


### PR DESCRIPTION
This PR adds basic Reading Lists support.

### Changes
- Added "Reading Lists" section to homepage with configurable visibility via toggle option to show/hide in settings
- Implemented `getReadingListDetails` function to fetch reading list metadata including title, cover image, and associated creators
- Added "rl-" prefix for reading list IDs to distinguish from regular series
- Modified `getChapters` to handle both series and reading lists

### Note about chapters ordering
Inside getChapters, there was an issue with the chapter order when using Reading Lists.
The chapter order was previously determined using the following values (if available):
 - Volume number
 - Chapter number

To fix this, I removed the Volume number and set the Chapter number to the corresponding Reading List's order.
Additionally, to clearly identify which series and issue a chapter belongs to, I updated the chapter name format to: `${seriesName} #${chapterNumber}`.

Maybe there is a better way to do it that I did not found.

